### PR TITLE
Forgot about rounding up

### DIFF
--- a/concurrent/src/main/scala/org/powerscala/concurrent/Time.scala
+++ b/concurrent/src/main/scala/org/powerscala/concurrent/Time.scala
@@ -342,9 +342,10 @@ case class Elapsed(time: Double) {
     } else {
       "ms"
     }
-    val s = if (value >= 2 && ending != "ms") "s" else ""
+    val round = math.round(value)
+    val s = if (round != 1 && ending != "ms") "s" else ""
 
-    s"${math.round(value)} $ending$s"
+    s"$round $ending$s"
   }
 
   override def toString = {


### PR DESCRIPTION
Woops, I overlooked Math.round and assumed this routine rounded down. The old patch would transform 1.7 weeks into "2 week".
